### PR TITLE
Test CI with Mongo 4.4 like wekan

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 java_version=17
 
-mongo_version=6.0
+mongo_version=4.4
 
 # Java dependencies used by the app will be installed through the Java helper
 pkg_dependencies=""


### PR DESCRIPTION
## Problem

- Switching to Mongo 4.4 as it seems Mongo 6.0 doesn't work with CI

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
