### PR TITLE
Trying to install buster version of Mongo 4.4

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 java_version=17
 
-mongo_version=6.0
+mongo_version=4.4
 
 # Java dependencies used by the app will be installed through the Java helper
 pkg_dependencies=""

--- a/scripts/install
+++ b/scripts/install
@@ -71,6 +71,7 @@ ynh_script_progression --message="Storing installation settings..." --weight=1
 
 ynh_app_setting_set --app=$app --key=domain --value=$domain
 ynh_app_setting_set --app=$app --key=path --value=$path_url
+ynh_app_setting_set --app=$app --key=is_public --value=$is_public
 
 #=================================================
 # STANDARD MODIFICATIONS

--- a/scripts/restore
+++ b/scripts/restore
@@ -32,6 +32,7 @@ app=$YNH_APP_INSTANCE_NAME
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
+is_public=$(ynh_app_setting_get --app=$app --key=is_public)
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 db_user=$(ynh_app_setting_get --app=$app --key=db_user)
 html_path=$(ynh_app_setting_get --app=$app --key=html_path)

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -20,6 +20,7 @@ app=$YNH_APP_INSTANCE_NAME
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path_url=$(ynh_app_setting_get --app=$app --key=path)
+is_public=$(ynh_app_setting_get --app=$app --key=is_public)
 port_ide=$(ynh_app_setting_get --app=$app --key=port_ide)
 port_preview=$(ynh_app_setting_get --app=$app --key=port_preview)
 port_project=$(ynh_app_setting_get --app=$app --key=port_project)
@@ -74,6 +75,12 @@ done
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
 #=================================================
+
+# Check or set the value of is_public
+if [ -e "$is_public" ]; then
+  is_public=true
+  ynh_app_setting_set --app=$app --key=is_public --value=$is_public
+fi
 
 # Create html_path if needed
 if [ -z "$html_path" ]; then


### PR DESCRIPTION
## Problem

- Mongo does not install

## Solution

- Installing the exact same version than wekan who worked
## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
